### PR TITLE
fix: update rand::thread_rng() to rand::rng() for rand 0.9 compatibility

### DIFF
--- a/api-server/src/kube/pod_manager.rs
+++ b/api-server/src/kube/pod_manager.rs
@@ -61,7 +61,7 @@ impl<T: PodOperations + ?Sized> PodManager<T> {
             // Randomly select a pod to avoid thundering herd
             let mut shuffled = pods.clone();
             {
-                let mut rng = rand::thread_rng();
+                let mut rng = rand::rng();
                 shuffled.shuffle(&mut rng);
                 // rng is dropped here, before any await points
             }


### PR DESCRIPTION
## Summary

- Updates `rand::thread_rng()` to `rand::rng()` in `api-server/src/kube/pod_manager.rs`
- rand 0.9 renamed `thread_rng()` to `rng()` — this was causing a Clippy deprecation error
- Unblocks Dependabot PR #20 (rand 0.8.5 → 0.9.2) which has all other checks passing

## Related

- Dependabot PR #20: Bump rand from 0.8.5 to 0.9.2
- repo-guardian tracking: Sayfan-AI/repo-guardian#27

🤖 Generated with [Claude Code](https://claude.com/claude-code)