### PR TITLE
chore: upgrade kube 0.87 → 0.99 to enable k8s-openapi 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 axum = { version = "0.8", features = ["macros"] }
 anyhow = "1.0"
 thiserror = "2.0"
-# k8s-openapi 0.20.x is pulled in by kube 0.87 and requires exactly one version feature.
-# We pin v1_28 here so all workspace members that (transitively) use k8s-openapi 0.20 get
-# the required feature flag, fixing the CI build failure.
-k8s-openapi = { version = "0.20", features = ["v1_28"] }
+k8s-openapi = { version = "0.24", features = ["v1_30"] }
 
 [profile.release]
 opt-level = 3

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = { workspace = true }
 k8s-openapi = { workspace = true }
 
 # Crate-specific
-kube = { version = "0.87", features = ["runtime", "derive"] }
+kube = { version = "0.99", features = ["runtime", "derive"] }
 reqwest = { version = "0.13", features = ["json"] }
 rand = "0.9"
 tower = "0.4"

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -23,7 +23,7 @@ k8s-openapi = { workspace = true }
 kube = { version = "0.99", features = ["runtime", "derive"] }
 reqwest = { version = "0.13", features = ["json"] }
 rand = "0.9"
-tower = "0.4"
+tower = { version = "0.4", features = ["util"] }
 tower-http = { version = "0.6", features = ["trace"] }
 async-trait = "0.1"
 

--- a/api-server/src/server.rs
+++ b/api-server/src/server.rs
@@ -36,6 +36,7 @@ mod tests {
         let app = build_router(state);
 
         let response = app
+            .into_service()
             .oneshot(
                 Request::builder()
                     .uri("/health")
@@ -63,6 +64,7 @@ mod tests {
         let request_body = r#"{"image_base64":"fake"}"#;
 
         let response = app
+            .into_service()
             .oneshot(
                 Request::builder()
                     .method("POST")

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -12,4 +12,4 @@ anyhow = { workspace = true }
 tokio = { workspace = true }
 k8s-openapi = { workspace = true }
 serde_json = { workspace = true }
-kube = { version = "0.87", features = ["runtime", "derive"] }
+kube = { version = "0.99", features = ["runtime", "derive"] }


### PR DESCRIPTION
Upgrades kube from 0.87 to 0.99 in api-server and test-utils. kube 0.99 requires k8s-openapi ^0.24, which eliminates the dual-version conflict that blocks Dependabot PR #22 (k8s-openapi 0.20→0.24). Closes Sayfan-AI/repo-guardian#28 (unblocks the-gigi/face-it#22).